### PR TITLE
Update dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Download
 #### Gradle
 
 ```
-compile 'com.github.tony19:loggly-client:1.0.3'
+compile 'com.github.tony19:loggly-client:1.0.4'
 ```
 
 #### Maven
@@ -118,7 +118,7 @@ compile 'com.github.tony19:loggly-client:1.0.3'
 <dependency>
   <groupId>com.github.tony19</groupId>
   <artifactId>loggly-client</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 


### PR DESCRIPTION
This PR is to update the `Loggly-Client` dependency to the next version which will call the HTTPS Loggly URL instead of HTTP URL. 

The current published version doesn't contain the HTTPS URL even when the GitHub master branch is updated with the HTTPS URL on line [#32](https://github.com/loggly/loggly-client/blob/master/loggly-client/src/main/java/com/github/tony19/loggly/LogglyClient.java#L32). 

**Note:** Please merge this PR before deploying the new package with bump version. 

Thanks!